### PR TITLE
Fix: refresh 토큰 재발행 복호화 오류 해결

### DIFF
--- a/src/middlewares/authToken.ts
+++ b/src/middlewares/authToken.ts
@@ -43,7 +43,8 @@ export const refreshToken: RequestHandler = async (req: Request, res: Response, 
     req.userId = userInfo.id as number; // userId를 req.userId에 저장
     next()
   }catch(err){
-    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({message:'서버 에러'});
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({message:'서버 에러 in refreshToken'});
+    console.log(err);
     return;
   }
 }

--- a/src/utils/authUtil.ts
+++ b/src/utils/authUtil.ts
@@ -50,7 +50,7 @@ export const passwordChangeToHash = async (password: string, salt: string): Prom
 };
 
 export const createAccessToken = async(userInfo: IUser) : Promise<string> => {
-  const secreyKey: string = process.env.ACCESS_TOKEN_SECRET_KEY || "";
+  const secreyKey: string = process.env.TOKEN_SECRET_KEY || "";
   try{
     const accessToken = jwt.sign(
       {
@@ -68,7 +68,7 @@ export const createAccessToken = async(userInfo: IUser) : Promise<string> => {
 }
 
 export const createRefreshToken = async(userInfo:IUser): Promise<string> => {
-  const secreyKey: string = process.env.REFRESH_TOKEN_SECRET_KEY || "";
+  const secreyKey: string = process.env.TOKEN_SECRET_KEY || "";
   try{
     const refreshToken = jwt.sign(
       {
@@ -86,7 +86,7 @@ export const createRefreshToken = async(userInfo:IUser): Promise<string> => {
 }
 
 export const verifyToken = async (token: string): Promise<IUser> => {
-  const secreyKey: string = process.env.ACCESS_TOKEN_SECRET_KEY || "";
+  const secreyKey: string = process.env.TOKEN_SECRET_KEY || "";
   try{
     const jwtPayload = jwt.verify(token, secreyKey) as JwtPayload;
     let userInfo : IUser = {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> refreshToken 함수에서 verifyToken 함수를 활용해 복호화 하는 과정에서 복호화 키를 accessToken key를 사용하여 Invalid signature 오류 발생

## 📝 작업 내용

> refresh Token과 access Token의 암호화 key를 하나로 통일 시킴.  

## 💬 리뷰 요구사항(선택)

> 보안을 고려했을 때, refresh Token과 access Token의 암호화 key를 다르게 하는 것이 맞는 것 같긴 함. 
    리뷰어님들의 의견 부탁드림.
