### PR TITLE
Feat: Oauth 소셜로그인 (네이버) 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+dist

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -115,7 +115,7 @@ export const kakaoLogin: RequestHandler = async (req: Request, res: Response): P
   const userInfo = req.userInfo;
   console.log(userInfo);
   try{
-    const tokens = await userService.kakaoLogin(userInfo);
+    const tokens = await userService.socialLogin(userInfo);
     console.log(tokens)
     if(tokens){
       res.header('Authorization', `Bearer ${tokens.accessToken}`);
@@ -131,6 +131,31 @@ export const kakaoLogin: RequestHandler = async (req: Request, res: Response): P
   }catch(err){
     console.log(err)
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({message:'kakaoLogin 서버 에러'});
+    return;
+  }
+};
+
+export const naverLogin: RequestHandler = async (req: Request, res: Response): Promise<void> => {
+  const userInfo = req.userInfo;
+  console.log(`naverLogin의 userInfo : ${userInfo}`);
+  try{
+    const tokens = await userService.socialLogin(userInfo);
+    console.log(tokens);
+
+    if(tokens){
+      res.header('Authorization', `Bearer ${tokens.accessToken}`);
+      res.cookie('refreshToken', tokens.refreshToken, {
+        httpOnly: true, 
+      });
+      res.status(StatusCodes.OK).json({message:'로그인'});
+      return;
+    }
+    res.status(StatusCodes.BAD_REQUEST).json({message:'이미 해당 email로 회원가입된 이력있음.'});
+    return;
+
+  }catch(err){
+    console.log(err)
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({message:'naverLogin 서버 에러'});
     return;
   }
 };

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -94,6 +94,25 @@ export const changePassword: RequestHandler = async (req: Request, res: Response
   }
 }
 
+export const changeUserInfo: RequestHandler = async (req: Request, res: Response): Promise<void> => {
+  try{
+    const userInfo = req.userInfo;
+    const {newName, newEmail} = req.body;
+    console.log(newName)
+    console.log(newEmail)
+    if(await userService.changeUserInfo(userInfo.email as string, newName, newEmail)){
+      res.status(StatusCodes.OK).json({message:'변경완료'});
+      return;
+    }
+    res.status(StatusCodes.BAD_REQUEST).json({message:'잘못된 요청입니다.'});
+    return;
+  }catch(err){
+    console.log(err);
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({message:'서버 에러'});
+    return;
+  }
+}
+
 export const deleteUser: RequestHandler = async (req: Request, res: Response): Promise<void> => {
   try{
     const userInfo = req.userInfo;

--- a/src/middlewares/validations.ts
+++ b/src/middlewares/validations.ts
@@ -38,3 +38,9 @@ export const changePasswordValidate = [
   body('newPassword').isString(),
   validate
 ]
+
+export const changeUserInfoValidate = [
+  body('newEmail').optional().isEmail(),
+  body('newName').optional().isString(),
+  validate
+]

--- a/src/repositories/userRepository.ts
+++ b/src/repositories/userRepository.ts
@@ -33,7 +33,7 @@ export const deleteUser = async(userInfo:IUser) => {
   }
 };
 
-export const updateUser = async (id:number, newHashPassword:string, salt:string) => {
+export const updatePassword = async (id:number, newHashPassword:string, salt:string) => {
   try{
     await db.User.update({
       hashPassword: newHashPassword,
@@ -44,6 +44,52 @@ export const updateUser = async (id:number, newHashPassword:string, salt:string)
     });
     return true
   }catch(err){
-    throw new Error(`userRepository updateUser err: ${(err as Error).message}`)
+    throw new Error(`userRepository updatePassword err: ${(err as Error).message}`)
+  }
+};
+
+export const updateAllUserInfo = async (id:number, newName:string, newEmail:string) => {
+  try{
+    await db.User.update({
+      name: newName,
+      email: newEmail
+    },
+    {
+      where: {id: id}
+    });
+    return true
+  }catch(err){
+    console.log(err);
+    throw new Error(`userRepository updateAllUserInfo err: ${(err as Error).message}`);
+  }
+};
+
+export const updateName = async (id:number, newName:string) => {
+  try{
+    await db.User.update({
+      name: newName,
+    },
+    {
+      where: {id: id}
+    });
+    return true
+  }catch(err){
+    console.log(err);
+    throw new Error(`userRepository updateName err: ${(err as Error).message}`);
+  }
+};
+
+export const updateEmail = async (id:number, newEmail:string) => {
+  try{
+    await db.User.update({
+      email: newEmail
+    },
+    {
+      where: {id: id}
+    });
+    return true
+  }catch(err){
+    console.log(err);
+    throw new Error(`userRepository updateEmail err: ${(err as Error).message}`);
   }
 };

--- a/src/routes/userRouter.ts
+++ b/src/routes/userRouter.ts
@@ -1,7 +1,7 @@
 import express from 'express';
-import {signup, login, logout, updateAccessToken, myPage, changePassword, deleteUser, kakaoLogin} from '../controllers/userController';
+import {signup, login, logout, updateAccessToken, myPage, changePassword, deleteUser, kakaoLogin, naverLogin} from '../controllers/userController';
 import {signupValidate, loginValidate, changePasswordValidate} from '../middlewares/validations';
-import { authToken, kakaoAuthToken, refreshToken } from '../middlewares/authToken';
+import { authToken, kakaoAuthToken, refreshToken, naverAuthToken } from '../middlewares/authToken';
 
 const router = express.Router();
 
@@ -18,4 +18,6 @@ router
   .delete(authToken, deleteUser);
 
 router.get('/oauth/kakao',kakaoAuthToken, kakaoLogin);
+router.get('/oauth/naver',naverAuthToken, naverLogin);
+
 export default router;

--- a/src/routes/userRouter.ts
+++ b/src/routes/userRouter.ts
@@ -1,6 +1,6 @@
 import express from 'express';
-import {signup, login, logout, updateAccessToken, myPage, changePassword, deleteUser, kakaoLogin, naverLogin} from '../controllers/userController';
-import {signupValidate, loginValidate, changePasswordValidate} from '../middlewares/validations';
+import {signup, login, logout, updateAccessToken, myPage, changePassword, deleteUser, kakaoLogin, naverLogin, changeUserInfo} from '../controllers/userController';
+import {signupValidate, loginValidate, changePasswordValidate, changeUserInfoValidate} from '../middlewares/validations';
 import { authToken, kakaoAuthToken, refreshToken, naverAuthToken } from '../middlewares/authToken';
 
 const router = express.Router();
@@ -14,8 +14,10 @@ router.get('/refresh', refreshToken, updateAccessToken);
 router
   .route('/account')
   .get(authToken, myPage)
-  .put(authToken, changePasswordValidate, changePassword)
+  .put(authToken, changeUserInfoValidate, changeUserInfo)
   .delete(authToken, deleteUser);
+
+router.put('/account/password', authToken, changePasswordValidate, changePassword);
 
 router.get('/oauth/kakao',kakaoAuthToken, kakaoLogin);
 router.get('/oauth/naver',naverAuthToken, naverLogin);

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -58,12 +58,34 @@ export const changePassword = async(email: string, password: string, newPassword
     if(await authUtil.isMatchPassword(userInfo, password) && password !== newPassword){
       const salt = await authUtil.createRandomSalt()
       const newHashPassword = await authUtil.passwordChangeToHash(newPassword, salt)
-      await userRepository.updateUser(userInfo.id, newHashPassword, salt)
+      await userRepository.updatePassword(userInfo.id, newHashPassword, salt)
       return true
     }
     return false
   }catch(err){
     throw new Error(`userService changePassword Err: ${(err as Error).message}`)
+  }
+}
+
+export const changeUserInfo = async(email: string, newName: string, newEmail: string) : Promise<boolean> => {
+  try{
+    const userInfo = await userRepository.selectUser(email);
+    if(newName && newEmail){
+      await userRepository.updateAllUserInfo(userInfo.id, newName, newEmail);
+      return true
+    }
+    if(newName){
+      await userRepository.updateName(userInfo.id, newName);
+      return true
+    }
+    if(newEmail){
+      await userRepository.updateEmail(userInfo.id, newEmail);
+      return true
+    }
+
+    return false
+  }catch(err){
+    throw new Error(`userService changeUserInfo Err: ${(err as Error).message}`)
   }
 }
 

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -96,20 +96,18 @@ export const myPage = async(email: string) : Promise<any> => {
   }
 }
 
-export const kakaoLogin = async (userInfo:any):Promise<any> => {
+export const socialLogin = async (userInfo:any):Promise<any> => {
   try{
     
     let searchedUserInfo = await userRepository.selectUser(userInfo.email);
     
-    if(!searchedUserInfo) {
-      userInfo = await authUtil.createHashPassword(userInfo)
-      await userRepository.createUser(userInfo)
-      searchedUserInfo = await userRepository.selectUser(userInfo.email);
-    }
-
-    if(searchedUserInfo.provider !== "kakao"){
+    if(searchedUserInfo) {
       return false
     }
+
+    userInfo = await authUtil.createHashPassword(userInfo)
+    await userRepository.createUser(userInfo)
+    searchedUserInfo = await userRepository.selectUser(userInfo.email);
 
     const accessToken = await authUtil.createAccessToken(searchedUserInfo);
     const refreshToken = await authUtil.createRefreshToken(searchedUserInfo);

--- a/src/utils/authUtil.ts
+++ b/src/utils/authUtil.ts
@@ -37,6 +37,30 @@ export const kakaoAuth = async (token: any): Promise<IUser> => {
   }
 }
 
+export const naverAuth = async (token: any): Promise<IUser> => {
+  try{
+    const naverUserInfo: any = await axios({
+      method : "GET",
+      url: "https://openapi.naver.com/v1/nid/me",
+      headers: {
+        Authorization: `Bearer ${token.data.access_token}`,
+      },
+    });
+    
+    console.log(`naverUserInfo : ${JSON.stringify(naverUserInfo.data.response)}`);
+
+    const userInfo: IUser = {
+      email: naverUserInfo.data.response.email,
+      name: naverUserInfo.data.response.name,
+      password: naverUserInfo.data.response.id,
+      provider: "naver"
+    }
+    return userInfo
+  }catch(err){
+    throw new Error(`kakaoAuth Err: ${(err as Error).message}`);
+  }
+}
+
 export const createHashPassword = async (userInfo: IUser): Promise<Object> => {
   try{
     const salt = await createRandomSalt();


### PR DESCRIPTION
## 📝 작업 내용

> Oauth 2.0을 활용한 네이버 소셜 로그인 구현

## 💬 리뷰 요구사항

> userService.ts / socialLogin 에서 email 값을 회원의 식별자로 사용하고 있어서 로그인 방법(로컬, 네이버, 카카오)에 상관 없이 DB에 이미 저장되어 있는 email일 경우 소셜 로그인 시 회원 가입 및 로그인을 허가하지 않고 있는데 이에 대해 어떻게 생각하시나요?
