### PR TITLE
fix: celebrationMsg과 invitation fk 연결 및 api 수정

### DIFF
--- a/src/models/celebrationMsg.ts
+++ b/src/models/celebrationMsg.ts
@@ -32,7 +32,13 @@ class CelebrationMsg extends Model<celebrationMsgData> {
         },
         invitationId: {
           type: DataTypes.INTEGER,
-          allowNull: false,
+          references: {
+            model: 'invitations',
+            key: 'id',
+          },
+          allowNull: true,
+          onUpdate: 'CASCADE',  
+          onDelete: 'CASCADE',
         },
         name: {
           type: DataTypes.STRING(10),

--- a/src/models/guestInfo.ts
+++ b/src/models/guestInfo.ts
@@ -33,7 +33,13 @@ class GuestInfo extends Model<attendanceData> implements attendanceData {
         },
         invitationId: {
           type: DataTypes.INTEGER,
-          allowNull: false,
+          references: {
+            model: 'invitations',
+            key: 'id',
+          },
+          allowNull: true,
+          onUpdate: 'CASCADE',  
+          onDelete: 'CASCADE',
         },
         name: {
           type: DataTypes.STRING(10),

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -76,6 +76,9 @@ db.Contact.belongsTo(db.Invitation, { foreignKey: 'invitationId', as: 'contacts'
 db.Invitation.hasMany(db.Notice, { foreignKey: 'invitationId', as: 'notices' });
 db.Notice.belongsTo(db.Invitation, { foreignKey: 'invitationId', as: 'notices' });
 
+db.Invitation.hasMany(db.CelebrationMsg, { foreignKey: 'invitationId', as: 'celebrationMsgs' });
+db.CelebrationMsg.belongsTo(db.Invitation, { foreignKey: 'invitationId', as: 'celebrationMsgs' });
+
 db.CelebrationMsg.belongsTo(db.User, { foreignKey: "userId" });
 
 export { sequelize };

--- a/src/repositories/invitationRepository.ts
+++ b/src/repositories/invitationRepository.ts
@@ -124,7 +124,11 @@ export const getInvitationsByUserId = async (userId: number) => {
             as : 'guestInfos',
             required: false,
           },
-          // 포토톡 추가
+          {
+            model: db.CelebrationMsg,
+            as : 'celebrationMsgs',
+            required: false,
+          },
           {
             model: db.Calendar,
             as: 'calendars',


### PR DESCRIPTION
## 📝 작업 내용

> 축하 메세지와 청첩장 테이블 간의 fk 연결 설정을 위해 코드를 수정하였습니다(models)
> 그리고 청첩장 전체 조회 api에서 축하 메세지의 정보를 함께 조회하도록 코드를 수정하였씁니다