### PR TITLE
fix: 갤러리 등록 시 에러 처리 추가

### DIFF
--- a/src/controllers/invitationController.ts
+++ b/src/controllers/invitationController.ts
@@ -3,6 +3,7 @@ import { StatusCodes } from "http-status-codes";
 import * as invitationService from "../services/invitationService";
 import { InvitationData } from "../interfaces/invitation.interface";
 import { User as IUser } from '../interfaces/user.interface';
+import { ClientError } from "../utils/error";
 
 const validateIdParam = (param: string): number => {
     const id = Number(param);
@@ -28,13 +29,18 @@ export const postInvitation: RequestHandler = async (req: Request, res: Response
                 message: '청첩장이 생성되었습니다.'
             });
             return;
-        }
+        } 
         res.status(StatusCodes.BAD_REQUEST).json({ 
             message: '청첩장 생성 실패.' 
         });
         
     } catch (err) {
-        next(err);
+        if (err instanceof ClientError) {
+            res.status(StatusCodes.BAD_REQUEST).json({ message: err.message });
+            return;
+        } else {
+            next(err);
+        }
     }
 };
 

--- a/src/services/invitationService.ts
+++ b/src/services/invitationService.ts
@@ -6,6 +6,7 @@ import { GalleryData } from '../interfaces/gallery.interface';
 import { AccountData } from '../interfaces/account.interface';
 import { ContactData } from '../interfaces/contact.interface';
 import { NoticeData } from '../interfaces/notice.interface';
+import { ClientError } from '../utils/error';
 
 type UpdateInvitation = Partial<Omit<InvitationData, 'id' | 'userId'>>;
 
@@ -31,6 +32,11 @@ export const createInvitation = async ( userId: number, invitationData: Omit<Inv
     }
 
     if (galleries && galleries.length > 0) { // 갤러리 정보가 들어오면 저장
+      
+      if (galleries.some(gallery => (gallery.images ?? []).length > 9)) {
+        throw new ClientError("갤러리의 이미지 개수는 최대 9개까지만 가능합니다.");
+      }
+
       const galleriesWithInvitationId = galleries.map((gallery) => ({
         ...gallery,
         invitationId: newInvitation.id,
@@ -66,6 +72,11 @@ export const createInvitation = async ( userId: number, invitationData: Omit<Inv
 
   } catch (err: unknown) {
     console.error('청첩장 등록 에러:', (err as Error).message);
+
+    if (err instanceof ClientError) { // ClientError의 경우 따로 처리
+      throw err;
+    }
+
     throw new Error('청첩장 등록 에러');
   }
 };

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,8 @@
+export class ClientError extends Error {
+  statusCode: number;
+  
+  constructor(message: string, statusCode = 400) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+};


### PR DESCRIPTION
## 📝 작업 내용

> 청첩장 - 갤러리 등록 시 갤러리 이미지의 갯수가 한 번에 10개 이상의 값으로 등록할 때 400 에러를 발생시키는 처리를 추가하였습니다
> 효율적인 에러 처리를 위해 utils / error.ts를 생성하여 호출하도록 구성하였습니다. 해당 파일은 포토톡 이미지 등록 에러 처리에서도 사용할 예정입니다
