### PR TITLE
Fix: 전체 참석 조회를 [pagination + 기본 전체 참석 조회]로 수정

### DIFF
--- a/src/controllers/attendanceController.ts
+++ b/src/controllers/attendanceController.ts
@@ -1,7 +1,11 @@
 import { Request, Response } from "express";
 import { StatusCodes } from "http-status-codes";
 import * as attendanceService from "../services/attendanceService";
-import { attendanceData } from "../interfaces/attendance.interface";
+import {
+  attendanceData,
+  paginatedAllAttendances,
+  allAttendances,
+} from "../interfaces/attendance.interface";
 import { User as IUser } from "../interfaces/user.interface";
 
 // api 예시 : http://localhost:3000/api/attendances?page=1&size=4
@@ -18,24 +22,62 @@ export const getAllAttendances = async (
     const page = parseInt(req.query.page as string);
     const size = parseInt(req.query.size as string);
 
-    // 서비스 호출
-    // totalItems : 전체 데이터의 총 항목 수 (db에 총 몇 개 저장되어 있는 지)
-    // totalPages : 페이지네이션으로 나눴을 때 생성되는 총 페이지 수
+    // 페이지네이션 쓸 때
+    if (page && size) {
+      const result = await attendanceService.getAllAttendances(
+        userId,
+        page,
+        size
+      );
 
-    const { allAttendances, totalItems, totalPages } =
-      await attendanceService.getAllAttendances(userId, page, size);
-
-    // const allAttendances = await attendanceService.getAllAttendances(userId);  // 원래 코드
-
-    if (allAttendances && allAttendances.length > 0) {
-      res.status(StatusCodes.OK).json({
-        allAttendances,
-        totalItems,
-        totalPages,
-        currentPage: page,
-      });
-      return;
+      if ("totalItems" in result && "totalPages" in result) {
+        const { allAttendances, totalItems, totalPages } = result;
+        if (allAttendances && allAttendances.length > 0) {
+          res.status(StatusCodes.OK).json({
+            allAttendances,
+            totalItems,
+            totalPages,
+            currentPage: page,
+          });
+          return;
+        }
+      }
     }
+    // const { allAttendances, totalItems, totalPages } =
+    // await attendanceService.getAllAttendances(userId, page, size);
+
+    // if (allAttendances && allAttendances.length > 0) {
+    //   res.status(StatusCodes.OK).json({
+    //     allAttendances,
+    //     totalItems,
+    //     totalPages,
+    //     currentPage: page,
+    //   });
+    //   return;
+    else {
+      // 페이지네이션 안 쓰는 전체 조회일 때
+      const result = await attendanceService.getAllAttendances(userId); // 원래 코드
+
+      // 결과가 배열로 오면 그 데이터를 그대로 응답
+      if (Array.isArray(result)) {
+        if (result.length > 0) {
+          res.status(StatusCodes.OK).json({
+            allAttendances: result,
+          });
+          return;
+        }
+      }
+      // if ("allAttendances" in result) {
+      //   const allAttendances = result.allAttendances;
+
+      //   if (allAttendances && allAttendances.length > 0) {
+      //     res.status(StatusCodes.OK).json({
+      //       allAttendances: result,
+      //     });
+      //     return;
+      //   }
+    }
+
     res
       .status(StatusCodes.NOT_FOUND)
       .json({ message: "전체 참석 정보가 존재하지 않습니다." });

--- a/src/repositories/attendanceRepository.ts
+++ b/src/repositories/attendanceRepository.ts
@@ -5,22 +5,36 @@ import GuestInfo from "../models/guestInfo";
 // 1. 전체 참석 정보 조회
 export const findAllAttendances = async (
   userId: number,
-  offset: number,
-  limit: number
+  offset: number = 0,
+  limit: number = 0
 ): Promise<GuestInfo[]> => {
   try {
-    console.log("모든 참석 정보를 불러오는 중입니다...");
-    const attendance = await db.GuestInfo.findAll({
-      where: { userId },
-      offset, // 시작 위치
-      limit, // 가져올 데이터 개수
-      order: [["id", "DESC"]], // 정렬 조건 : descending(내림차순)
-    });
-    if (!attendance) {
-      console.log("전체 참석 정보가 없습니다.");
+    // 페이지네이션 있을 때
+    if (offset && limit) {
+      console.log("모든 참석 정보를 불러오는 중입니다...");
+      const attendance = await db.GuestInfo.findAll({
+        where: { userId },
+        offset, // 시작 위치
+        limit, // 가져올 데이터 개수
+        order: [["id", "DESC"]], // 정렬 조건 : descending(내림차순)
+      });
+      if (!attendance) {
+        console.log("전체 참석 정보가 없습니다.");
+      }
+      console.log("모든 참석 정보가 불러와졌습니다. : ", attendance);
+      return attendance;
+    } else {
+      // 페이지네이션 안 쓸 때
+      console.log("모든 참석 정보를 불러오는 중입니다...");
+      const attendance = await db.GuestInfo.findAll({
+        where: { userId },
+      });
+      if (!attendance) {
+        console.log("전체 참석 정보가 없습니다.");
+      }
+      console.log("모든 참석 정보가 불러와졌습니다. : ", attendance);
+      return attendance;
     }
-    console.log("모든 참석 정보가 불러와졌습니다. : ", attendance);
-    return attendance;
   } catch (error: unknown) {
     const errorMessage =
       error instanceof Error

--- a/src/services/attendanceService.ts
+++ b/src/services/attendanceService.ts
@@ -4,32 +4,36 @@ import { attendanceData } from "../interfaces/attendance.interface";
 // 1. 전체 참석 정보 조회
 export const getAllAttendances = async (
   userId: number,
-  page: number,
-  size: number
+  page: number = 0,
+  size: number = 0
 ) => {
   try {
     // 시작 위치 계산
     const offset = (page - 1) * size;
     const limit = size;
 
-    // repo 호출
-    const allAttendances = await attendanceRepository.findAllAttendances(
-      userId,
-      offset,
-      limit
-    );
+    // 페이지네이션 있을 때
+    if (page > 0 && size > 0) {
+      // repo 호출
+      const allAttendances = await attendanceRepository.findAllAttendances(
+        userId,
+        offset,
+        limit
+      );
 
-    // 전체 데이터 개수 및 총 페이지 계산
-    const totalItems = await attendanceRepository.countAttendances(userId);
-    const totalPages = Math.ceil(totalItems / size);
+      // 전체 데이터 개수 및 총 페이지 계산
+      const totalItems = await attendanceRepository.countAttendances(userId);
+      const totalPages = Math.ceil(totalItems / size);
 
-    return {
-      allAttendances,
-      totalItems,
-      totalPages,
-    };
-
-    // return await attendanceRepository.findAllAttendances(userId);    // 원래 코드
+      return {
+        allAttendances,
+        totalItems,
+        totalPages,
+      };
+    } else {
+      // 페이지네이션 안 쓸 때 (page와 size의 기본값이 0)
+      return await attendanceRepository.findAllAttendances(userId); // 원래 코드
+    }
   } catch (error: unknown) {
     const errorMessage =
       error instanceof Error


### PR DESCRIPTION
이전에 전체 참석 조회를 페이지네이션이 포함된 코드로 수정했었으나,
 api의 url 쿼리 유무에 따라 response를 수정해달라는 요청에 따라 코드를 다시 수정함

[수정 후 결과]
1. api/attendances -> userId에 따른 전체 참석 조회 response
2. api/attendances?page=?&size=? -> 전체 참석 조회 pagination response
반환값이 다르게 되게끔 코드 수정함