### PR TITLE
add: s3 이미지 삭제 기능 구현

### DIFF
--- a/src/controllers/s3Controller.ts
+++ b/src/controllers/s3Controller.ts
@@ -1,5 +1,8 @@
 import { Request, Response, RequestHandler } from "express";
 import { StatusCodes } from "http-status-codes";
+import { deleteImageFromS3 } from "../utils/s3";
+import { extractS3KeyFromUrl } from "../utils/s3";
+import { getInvitationById } from "../repositories/invitationRepository";
 
 export const postImage: RequestHandler = async (req: Request, res: Response): Promise<void> => {
   try {
@@ -16,5 +19,76 @@ export const postImage: RequestHandler = async (req: Request, res: Response): Pr
   } catch (error) {
     console.error("이미지 업로드 오류:", error);
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: "서버 에러" });
+  }
+};
+
+export const deleteImageById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const id = Number(req.params.id);
+
+    if (isNaN(id)) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "유효한 초대장 ID가 필요합니다." });
+      return;
+    }
+
+    const invitation = await getInvitationById(id);
+
+    if (!invitation) {
+      res.status(StatusCodes.NOT_FOUND).json({ message: "해당 초대장이 존재하지 않습니다." });
+      return;
+    }
+
+    const urlsToDelete: string[] = []; 
+
+    if (invitation.imgUrl) { // 청첩장의 대표 이미지
+      urlsToDelete.push(invitation.imgUrl);
+    }
+
+    if (invitation.galleries?.length) { // 갤러리의 이미지들
+      invitation.galleries.forEach((gallery: any) => {
+        if (typeof gallery.images === 'string') {
+          try {
+            const parsedImages = JSON.parse(gallery.images);
+            if (Array.isArray(parsedImages)) {
+              parsedImages.forEach((imgUrl: string) => {
+                if (typeof imgUrl === 'string') {
+                  urlsToDelete.push(imgUrl);
+                }
+              });
+            }
+          } catch (err) {
+            console.warn("images JSON 파싱 실패:", gallery.images);
+          }
+        }
+      });
+    }    
+
+    if (invitation.notices?.length) { // 공지사항의 이미지
+      invitation.notices.forEach((notice: any) => {
+        if (notice.image) {
+          urlsToDelete.push(notice.image);
+        }
+      });
+    }
+
+    for (const url of urlsToDelete) {
+      const key = extractS3KeyFromUrl(url);
+      if (!key) {
+        console.warn("S3 key 추출 실패:", url);
+        continue;
+      }
+    
+      try {
+        await deleteImageFromS3(key);
+        console.log(`삭제 성공: ${key}`);
+      } catch (err) {
+        console.error(`삭제 실패 (${key}):`, (err as Error).message);
+      }
+    }    
+
+    res.status(StatusCodes.OK).json({ message: "모든 관련 이미지가 성공적으로 삭제되었습니다." });
+  } catch (error: any) {
+    console.error("이미지 삭제 오류:", error);
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: error.message });
   }
 };

--- a/src/routes/s3Router.ts
+++ b/src/routes/s3Router.ts
@@ -1,9 +1,11 @@
 import express from 'express';
 import { postImage } from '../controllers/s3Controller';
+import { deleteImageById } from '../controllers/s3Controller';
 import imageUploader from '../utils/s3';
 
 const router = express.Router();
 
 router.post('/', imageUploader.array("images"), postImage);
+router.delete('/:id', deleteImageById);
 
 export default router;

--- a/src/utils/s3.ts
+++ b/src/utils/s3.ts
@@ -31,4 +31,36 @@ const imageUploader = multer({ // multer 설정
     }),
 });
 
+const s3 = new AWS.S3();
+
+export const deleteImageFromS3 = async (key: string): Promise<void> => { // 이미지 삭제
+    const bucket = process.env.AWS_BUCKET_NAME as string;
+  
+    // 해당 key가 실제로 존재하는지 먼저 확인
+    try {
+      await s3.headObject({ Bucket: bucket, Key: key }).promise();
+    } catch (err: any) {
+      if (err.code === 'NotFound') {
+        throw new Error('해당 key의 파일이 존재하지 않습니다.');
+      }
+      throw new Error('S3 확인 중 오류 발생: ' + err.message);
+    }
+  
+    // 존재하면 삭제 실행
+    try {
+      await s3.deleteObject({ Bucket: bucket, Key: key }).promise();
+    } catch (err: any) {
+      throw new Error('S3 삭제 중 오류 발생: ' + err.message);
+    }
+  };
+
+export const extractS3KeyFromUrl = (url: string): string | null => { // url 값 추출
+  try {
+    const { pathname } = new URL(url);
+    return decodeURIComponent(pathname).slice(1); 
+  } catch {
+    return null;
+  }
+};
+  
 export default imageUploader;


### PR DESCRIPTION
## 📝 작업 내용

> s3에 업로드된 이미지를 삭제하는 기능을 구현하였습니다.
> 프론트로부터 삭제하고자 하는 invitation의 id를 params로 넘겨오면 해당 id의 invitation의 대표 이미지와 fk로 연결된 gallery와 notice(갤러리, 공지사항)의 이미지를 한 번에 모두 삭제하도록 구성하였습니다.
> 청첩장 삭제 시 청첩장 삭제 api와 이 s3 삭제 api를 함께 호출하면 청첩장과 s3에 업로드된 이미지들이 모두 삭제될 것입니다.
> api는 localhost:3000/api/s3/{청첩장 id} 로 호출하시면 됩니다.

## 💬 리뷰 요구사항
> 프론트에서 테스트해보시고 문제가 생긴다면 언제든 알려주세요!