### PR TITLE
feat : admin으로 celebrationMsg 삭제 가능하도록 api 추가

### DIFF
--- a/src/controllers/celebrationMsgController.ts
+++ b/src/controllers/celebrationMsgController.ts
@@ -177,3 +177,39 @@ export const deleteMyCelebrationMsg = async (
     res.status(StatusCodes.BAD_REQUEST).json({ message: "서버 에러" });
   }
 };
+
+// 관리자 모드 포토톡 삭제 기능 + delete
+export const deleteCelebrationMsgByAdmin = async (
+  req: Request<{ id: string }>,
+  res: Response
+): Promise<void> => {
+  try {
+    const userInfo: IUser = req.userInfo;
+
+    if (!userInfo) {
+      res
+        .status(StatusCodes.UNAUTHORIZED)
+        .json({ message: "로그인이 필요합니다." });
+      return;
+    }
+
+    const { id } = req.params;
+    const isDeleted = await celebrationMsgService.removeCelebrationMsgByAdmin(
+      Number(id)
+    );
+
+    if (!isDeleted) {
+      res
+        .status(404)
+        .json({ message: "삭제할 축하메세지를 찾을 수 없습니다." });
+      return;
+    }
+
+    res
+      .status(200)
+      .json({ message: "축하메세지가 성공적으로 삭제되었습니다." });
+  } catch (error) {
+    console.error(error);
+    res.status(StatusCodes.BAD_REQUEST).json({ message: "서버 에러" });
+  }
+};

--- a/src/repositories/celebrationMsgRepository.ts
+++ b/src/repositories/celebrationMsgRepository.ts
@@ -173,3 +173,35 @@ export const removeMyCelebrationMsgByPassword = async (
     );
   }
 };
+
+// 6. 관리자 모드 포토톡 삭제 기능 + delete
+export const removeCelebrationMsgByAdmin = async (
+  id: number
+): Promise<boolean> => {
+  try {
+    const celebrationMsg = await db.CelebrationMsg.findOne({
+      where: { id },
+    });
+
+    if (!celebrationMsg) {
+      console.log(
+        `다음 관리자 아이디로 삭제할 축하메세지 정보가 없습니다. id : ${id}`
+      );
+      return false;
+    }
+
+    await db.CelebrationMsg.destroy({ where: { id } });
+    console.log(
+      `다음 관리자 아이디로 해당 축하메세지 정보를 성공적으로 삭제했습니다. id : ${id}`
+    );
+    return true;
+  } catch (error: unknown) {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : "알 수 없는 오류가 발생했습니다.";
+    throw new Error(
+      `다음 관리자 아이디로 해당 축하메세지 정보 삭제에 실패했습니다. (id : ${id}) : ${errorMessage}`
+    );
+  }
+};

--- a/src/routes/celebrationMsgRouter.ts
+++ b/src/routes/celebrationMsgRouter.ts
@@ -7,6 +7,7 @@ import {
   postMyCelebrationMsg,
   putMyCelebrationMsg,
   deleteMyCelebrationMsg,
+  deleteCelebrationMsgByAdmin,
 } from "../controllers/celebrationMsgController";
 import { authToken } from "../middlewares/authToken";
 
@@ -22,7 +23,10 @@ router.post("/", postMyCelebrationMsg);
 // 4. 개인 축하메세지 수정
 router.put("/:id", putMyCelebrationMsg);
 
-// 4. 개인 축하메세지 삭제
+// 5. 개인 축하메세지 삭제
 router.delete("/:id", deleteMyCelebrationMsg);
+
+// 6. 개인 축하메세지 어드민 삭제
+router.delete("/admin/:id", authToken, deleteCelebrationMsgByAdmin);
 
 export default router;

--- a/src/services/celebrationMsgService.ts
+++ b/src/services/celebrationMsgService.ts
@@ -73,7 +73,7 @@ export const postMyCelebrationMsg = async (
   celebrationMsgData: celebrationMsgData
 ) => {
   try {
-    if(celebrationMsgData.imageUrl.length > 10) {
+    if (celebrationMsgData.imageUrl.length > 10) {
       throw new ClientError("이미지 개수는 최대 10개까지 가능합니다.");
     }
     return await celebrationMsgRepository.createMyCelebrationMsg(
@@ -134,6 +134,38 @@ export const deleteMyCelebrationMsg = async (
         : "알 수 없는 오류가 발생했습니다.";
     throw new Error(
       `다음 이름과 비밀번호로 기록된 축하메세지 정보 삭제에 실패했습니다. name : ${name}, password : ${password} : ${errorMessage}`
+    );
+  }
+};
+
+// 6. 관리자 모드 포토톡 삭제 기능 + delete    // 토큰에서 userId 받아와서 일치하는 경우 -> 어드민 api 수행 -> 바로 삭제 가능하게
+export const removeCelebrationMsgByAdmin = async (
+  id: number
+): Promise<boolean> => {
+  try {
+    console.log(
+      `관리자의 권한으로 축하메세지 정보 삭제 시도중입니다.. id : ${id}`
+    );
+
+    const celebrationMsg =
+      await celebrationMsgRepository.removeCelebrationMsgByAdmin(id);
+
+    if (!celebrationMsg) {
+      console.log(`삭제할 축하메세지 정보가 없습니다. id : ${id}`);
+      return false;
+    }
+
+    console.log(`축하메세지 삭제에 성공했습니다. id : ${id}`);
+
+    return true;
+  } catch (error: unknown) {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : "알 수 없는 오류가 발생했습니다.";
+
+    throw new Error(
+      `관리자로 축하메세지 삭제에 실패했습니다. (id: ${id}) : ${errorMessage}`
     );
   }
 };


### PR DESCRIPTION
### - pr 요약
1. celebrationMsg를 관리자 권한으로 삭제할 수 있도록 따로 api를 생성함
2. 추후 interface에 role 속성 추가하여 보안 강화 수정이 필요함.

### - pr 자세히
1. 관리자 api로 축하메세지 삭제하기(이름, 비밀번호 필요 없음, header에 token 값만 존재하면 됨, req body값 필요 없음)

2. api : localhost:3000/api/celebrationMsgs/admin/id
(로컬일 경우)

3. 필요 요소 : admin을 그냥 따로 api로 작성함(쿼리문 아님) / router도 따로 연결해서, 축하메세지 삭제 api 종류가 2가지임 (1. 이름 + 비밀번호 삭제 / 2. admin 삭제)