### PR TITLE
add: 포토톡 S3 이미지 삭제 API 구현

### DIFF
--- a/src/controllers/s3Controller.ts
+++ b/src/controllers/s3Controller.ts
@@ -22,7 +22,7 @@ export const postImage: RequestHandler = async (req: Request, res: Response): Pr
   }
 };
 
-export const deleteImageById = async (req: Request, res: Response): Promise<void> => {
+export const deleteInvitationImageById = async (req: Request, res: Response): Promise<void> => {
   try {
     const id = Number(req.params.id);
 

--- a/src/controllers/s3Controller.ts
+++ b/src/controllers/s3Controller.ts
@@ -92,3 +92,23 @@ export const deleteInvitationImageById = async (req: Request, res: Response): Pr
     res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: error.message });
   }
 };
+
+export const deleteCelebrationMsgImageById = async (req: Request, res: Response): Promise<void> => {
+
+};
+
+export const updateInvitationImageById = async (req: Request, res: Response): Promise<void> => {
+
+};
+
+export const updateGalleryImageById = async (req: Request, res: Response): Promise<void> => {
+
+}; // index 필요
+
+export const updateNoticeImageById = async (req: Request, res: Response): Promise<void> => {
+
+};
+
+export const updateCelebrationMsgImageById = async (req: Request, res: Response): Promise<void> => {
+
+}; // index 필요

--- a/src/routes/s3Router.ts
+++ b/src/routes/s3Router.ts
@@ -1,11 +1,15 @@
 import express from 'express';
-import { postImage } from '../controllers/s3Controller';
-import { deleteInvitationImageById } from '../controllers/s3Controller';
+import { postImage, deleteInvitationImageById, deleteCelebrationMsgImageById, updateCelebrationMsgImageById, updateInvitationImageById, updateGalleryImageById, updateNoticeImageById } from '../controllers/s3Controller';
 import imageUploader from '../utils/s3';
 
 const router = express.Router();
 
 router.post('/', imageUploader.array("images"), postImage);
-router.delete('/:id', deleteInvitationImageById);
+router.delete('/invitations/:id', deleteInvitationImageById);
+router.delete('/celebrationMsgs/:id', deleteCelebrationMsgImageById);
+router.put('/invitations/:id', updateInvitationImageById);
+router.put('/galleries/:id', updateGalleryImageById); // index
+router.put('/notices/:id', updateNoticeImageById);
+router.put('/celebrationMsgs/:id', updateCelebrationMsgImageById); // index
 
 export default router;

--- a/src/routes/s3Router.ts
+++ b/src/routes/s3Router.ts
@@ -1,11 +1,11 @@
 import express from 'express';
 import { postImage } from '../controllers/s3Controller';
-import { deleteImageById } from '../controllers/s3Controller';
+import { deleteInvitationImageById } from '../controllers/s3Controller';
 import imageUploader from '../utils/s3';
 
 const router = express.Router();
 
 router.post('/', imageUploader.array("images"), postImage);
-router.delete('/:id', deleteImageById);
+router.delete('/:id', deleteInvitationImageById);
 
 export default router;


### PR DESCRIPTION
## 📝 작업 내용

> 포토톡 S3 이미지 삭제 API를 구현했습니다. 경로는 /api/s3/celebrationMsgs/id로 실행하시면 되고 id는 삭제하고자 하는 포토톡의 id를 사용하면 됩니다.
> 추가적으로 S3 이미지 삭제, 수정에 대한 모든 API 라우팅을 설정했습니다. 삭제 API는 모두 구현이 되어있고 수정 API들은 곧 구현할 예정입니다.

## 💬 리뷰 요구사항
> 프론트에서 포토톡 S3 이미지 삭제 API 테스트 해보시고 문제가 있으시면 말씀해주세요!
