### PR TITLE
add: 청첩장, 공지사항 s3 이미지 수정 api 구현

### DIFF
--- a/src/controllers/s3Controller.ts
+++ b/src/controllers/s3Controller.ts
@@ -161,16 +161,134 @@ export const deleteCelebrationMsgImageById = async (req: Request, res: Response)
 };
 
 export const updateInvitationImageById = async (req: Request, res: Response): Promise<void> => {
+  // 1) params의 id 값 변수에 넣고 db(invitation)에 접근해서 값 빼내서 변수에 저장
+  // 2) 빼낸 s3 url에 접근해서 이미지 삭제
+  // 3) form-data로 받아온 이미지를 새로 s3에 업로드하고 반환(이는 postImage 활용)
+  // 4) 반환한 새로운 s3 url 값을 res로 전달
+  try {
+    // 1)
+    const id = Number(req.params.id);
 
+    if (isNaN(id)) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "유효한 초대장 ID가 필요합니다." });
+      return;
+    }
+
+    const invitation = await getInvitationById(id);
+
+    if (!invitation) {
+      res.status(StatusCodes.NOT_FOUND).json({ message: "해당 초대장이 존재하지 않습니다." });
+      return;
+    }
+
+    const oldImgUrl = invitation.imgUrl;
+
+    if (!oldImgUrl) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "청첩장의 대표 이미지가 존재하지 않습니다." });
+      return;
+    }
+    
+    // 2)
+    const key = extractS3KeyFromUrl(oldImgUrl);
+
+    if(!key) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "S3 이미지 키 추출 실패" });
+      return;
+    }
+
+    try {
+      await deleteImageFromS3(key);
+      console.log(`기존 이미지 삭제 완료: ${key}`);
+    } catch (err) {
+      console.error("기존 이미지 삭제 실패:", err);
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: "기존 이미지 삭제 중 오류가 발생했습니다." });
+      return;
+    }
+
+    // 3)
+    const files = req.files as Express.MulterS3.File[];
+
+    if (!files || files.length === 0) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "이미지 파일이 필요합니다." });
+      return;
+    }
+
+    // 4)
+    const imageUrls = files.map(file => file.location); // 이미지가 저장된 경로 반환
+
+    console.log(`새로운 이미지 등록 완료`);
+    res.status(StatusCodes.OK).json({ imageUrls });
+  } catch(error: any){
+    console.log("이미지 수정 오류:", error);
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: error.message });
+  }
+};
+
+export const updateNoticeImageById = async (req: Request, res: Response): Promise<void> => {
+  try {
+    // 1)
+    const id = Number(req.params.id);
+
+    if (isNaN(id)) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "유효한 초대장 ID가 필요합니다." });
+      return;
+    }
+
+    const notice = await db.Notice.findOne({
+      where: { id },
+    });
+
+    if (!notice) {
+      res.status(StatusCodes.NOT_FOUND).json({ message: "해당 공지사항이 존재하지 않습니다." });
+      return;
+    }
+
+    const oldImgUrl = notice.image;
+
+    if (!oldImgUrl) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "공지사항의 이미지가 존재하지 않습니다." });
+      return;
+    }
+    
+    // 2)
+    const key = extractS3KeyFromUrl(oldImgUrl);
+
+    if(!key) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "S3 이미지 키 추출 실패" });
+      return;
+    }
+
+    try {
+      await deleteImageFromS3(key);
+      console.log(`기존 이미지 삭제 완료: ${key}`);
+    } catch (err) {
+      console.error("기존 이미지 삭제 실패:", err);
+      res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: "기존 이미지 삭제 중 오류가 발생했습니다." });
+      return;
+    }
+
+    // 3)
+    const files = req.files as Express.MulterS3.File[];
+
+    if (!files || files.length === 0) {
+      res.status(StatusCodes.BAD_REQUEST).json({ message: "이미지 파일이 필요합니다." });
+      return;
+    }
+
+    // 4)
+    const imageUrls = files.map(file => file.location); // 이미지가 저장된 경로 반환
+
+    console.log(`새로운 이미지 등록 완료`);
+    res.status(StatusCodes.OK).json({ imageUrls });
+  } catch(error: any){
+    console.log("이미지 수정 오류:", error);
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: error.message });
+  }
 };
 
 export const updateGalleryImageById = async (req: Request, res: Response): Promise<void> => {
 
 }; // index 필요
-
-export const updateNoticeImageById = async (req: Request, res: Response): Promise<void> => {
-
-};
 
 export const updateCelebrationMsgImageById = async (req: Request, res: Response): Promise<void> => {
 

--- a/src/routes/s3Router.ts
+++ b/src/routes/s3Router.ts
@@ -7,9 +7,9 @@ const router = express.Router();
 router.post('/', imageUploader.array("images"), postImage);
 router.delete('/invitations/:id', deleteInvitationImageById);
 router.delete('/celebrationMsgs/:id', deleteCelebrationMsgImageById);
-router.put('/invitations/:id', updateInvitationImageById);
-router.put('/galleries/:id', updateGalleryImageById); // index
-router.put('/notices/:id', updateNoticeImageById);
-router.put('/celebrationMsgs/:id', updateCelebrationMsgImageById); // index
+router.put('/invitations/:id', imageUploader.array("images"), updateInvitationImageById);
+router.put('/notices/:id', imageUploader.array("images"), updateNoticeImageById);
+router.put('/galleries/:id', imageUploader.array("images"), updateGalleryImageById); // index
+router.put('/celebrationMsgs/:id', imageUploader.array("images"), updateCelebrationMsgImageById); // index
 
 export default router;


### PR DESCRIPTION
## 📝 작업 내용

> 청첩장과 공지사항의 s3 이미지 수정 api를 구현했습니다. 각 이미지는 청첩장(invitation)의 대표 이미지와 공지사항(galleries)의 이미지를 의미합니다.

## 💬 리뷰 요구사항
> 라우팅과 api 호출 과정은 팀 우결 노션 / 개발 문서 / 백엔드 / s3 이미지 관리에 작성해놨으니 참고하셔서 테스트해주시면 감사하겠습니다. 테스트 시 에러가 생긴다면 연락주세요!
