### PR TITLE
Fix: 하객용 축하메세지 전체 조회 수정

### DIFF
--- a/src/controllers/celebrationMsgController.ts
+++ b/src/controllers/celebrationMsgController.ts
@@ -49,7 +49,7 @@ export const getAllCelebrationMsgsForGuest = async (
     if (!id) {
       res
         .status(StatusCodes.BAD_REQUEST)
-        .json({ message: "invitationId가 존재하지 않습니다. (잘못된 요청)" });
+        .json({ message: "userId가 존재하지 않습니다. (잘못된 요청)" });
       return;
     }
 

--- a/src/repositories/celebrationMsgRepository.ts
+++ b/src/repositories/celebrationMsgRepository.ts
@@ -34,14 +34,14 @@ export const findAllcelebrationMsgs = async (
 
 // 1-1 전체 축하메세지 정보 조회 (하객용)
 export const findAllcelebrationMsgsForGuest = async (
-  invitationId: number,
+  userId: number,
   offset: number,
   limit: number
 ): Promise<CelebrationMsg[]> => {
   try {
     console.log("모든 축하메세지 기록을 불러오는 중입니다...");
     const celebrationMsg = await db.CelebrationMsg.findAll({
-      where: { invitationId },
+      where: { userId },
       offset,
       limit,
       order: [["id", "DESC"]],
@@ -70,9 +70,9 @@ export const countCelebrationMsgs = async (userId: number) => {
 };
 
 // 개수 세기 (하객용)
-export const countCelebrationMsgsForGuest = async (invitationId: number) => {
+export const countCelebrationMsgsForGuest = async (userId: number) => {
   return await CelebrationMsg.count({
-    where: { invitationId },
+    where: { userId },
   });
 };
 

--- a/src/services/celebrationMsgService.ts
+++ b/src/services/celebrationMsgService.ts
@@ -46,7 +46,7 @@ export const getAllCelebrationMsgs = async (
 };
 
 export const getAllCelebrationMsgsForGuest = async (
-  invitationId: number,
+  userId: number,
   page: number,
   size: number
 ) => {
@@ -58,14 +58,14 @@ export const getAllCelebrationMsgsForGuest = async (
     // repo 호출
     const allCelebrationMsgs =
       await celebrationMsgRepository.findAllcelebrationMsgsForGuest(
-        invitationId,
+        userId,
         offset,
         limit
       );
 
     // 전체 데이터 개수 및 총 페이지 계산
     const totalItems = await celebrationMsgRepository.countCelebrationMsgsForGuest(
-      invitationId
+      userId
     );
     const totalPages = Math.ceil(totalItems / size);
 
@@ -75,7 +75,6 @@ export const getAllCelebrationMsgsForGuest = async (
       totalPages,
     };
 
-    // return await celebrationMsgRepository.findAllcelebrationMsgs(userId);
   } catch (error: unknown) {
     const errorMessage =
       error instanceof Error


### PR DESCRIPTION
## 📝 작업 내용

> 여러 버전 (어르신 용, 젊은이 용)의 청첩장에 포함된 모든 축하메세지를 한번에 조회 할 수 있도록 기존 invitationId를 기준으로 검색하던 것을 userId를 기준으로 검색하여 조회 하도록 수정하였음.

