### PR TITLE
feat: 전체 축하메세지 이미지 조회(관리자 및 하객용) API 추가

### DIFF
--- a/src/controllers/celebrationMsgController.ts
+++ b/src/controllers/celebrationMsgController.ts
@@ -220,7 +220,7 @@ export const deleteMyCelebrationMsg = async (
   }
 };
 
-// 관리자 모드 포토톡 삭제 기능 + delete
+// 5-1. 관리자 모드 포토톡 삭제 기능 + delete
 export const deleteCelebrationMsgByAdmin = async (
   req: Request<{ id: string }>,
   res: Response
@@ -257,3 +257,73 @@ export const deleteCelebrationMsgByAdmin = async (
       .json({ message: "서버 에러" });
   }
 };
+
+// 6. 전체 축하메세지 이미지 조회(관리자용) + get
+export const getAllCelebrationMsgImages = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const userInfo: IUser = req.userInfo;
+    const userId = userInfo.id as number;
+
+    if (!userInfo) {
+      res
+        .status(StatusCodes.UNAUTHORIZED)
+        .json({ message: "userInfo가 존재하지 않습니다. 인증 실패" });
+      return;
+    }
+
+    const page = parseInt(req.query.page as string);
+    const size = parseInt(req.query.size as string);
+
+    const { imageUrls, totalItems, totalPages } =
+      await celebrationMsgService.getAllCelebrationMsgImages(userId, page, size);
+
+    res.status(StatusCodes.OK).json({
+      imageUrls,
+      totalItems,
+      totalPages,
+      currentPage: page,
+    });
+  } catch (err: any) {
+    console.error(err);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: "서버 에러" });
+  }
+};
+
+// 6-1. 전체 축하메세지 이미지 조회(하객용) + get
+export const getAllCelebrationMsgImagesForGuest = async (
+  req: Request<{ id: number }>,
+  res: Response
+): Promise<void> => {
+  try {
+    const { id } = req.params;
+
+    if (!id) {
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: "userId가 존재하지 않습니다. (잘못된 요청)" });
+      return;
+    }
+
+    // 페이지네이션 파라미터 받기
+    const page = parseInt(req.query.page as string);
+    const size = parseInt(req.query.size as string);
+
+    const { imageUrls, totalItems, totalPages } =
+      await celebrationMsgService.getAllCelebrationMsgImagesForGuest(id, page, size);
+
+    res
+      .status(StatusCodes.OK)
+      .json({ imageUrls, totalItems, totalPages, currentPage: page });
+  } catch (err: any) {
+    console.error(err);
+    res
+      .status(StatusCodes.INTERNAL_SERVER_ERROR)
+      .json({ message: "서버 에러" });
+  }
+};
+

--- a/src/routes/celebrationMsgRouter.ts
+++ b/src/routes/celebrationMsgRouter.ts
@@ -1,6 +1,5 @@
-import express, { Request, Response, Router } from "express";
+import express, { Router } from "express";
 
-const router: Router = express.Router();
 import {
   getAllCelebrationMsgs,
   getMyCelebrationMsg,
@@ -9,8 +8,13 @@ import {
   deleteMyCelebrationMsg,
   deleteCelebrationMsgByAdmin,
   getAllCelebrationMsgsForGuest,
+  getAllCelebrationMsgImages,
+  getAllCelebrationMsgImagesForGuest
 } from "../controllers/celebrationMsgController";
+
 import { authToken } from "../middlewares/authToken";
+
+const router: Router = express.Router();
 
 /**
  * @openapi
@@ -197,22 +201,28 @@ import { authToken } from "../middlewares/authToken";
 // 1. 전체 축하메세지 조회
 router.get("/", authToken, getAllCelebrationMsgs);
 
-//1-2. 전체 축하메세지 조회(하객용)
+// 1-2. 전체 축하메세지 조회(하객용)
 router.get("/guest/:id", getAllCelebrationMsgsForGuest);
 
-// 2. 개인 축하메세지 조회
+// 2. 전체 축하메세지 이미지 조회(관리자용)
+router.get("/images", authToken, getAllCelebrationMsgImages);
+
+// 2-2. 전체 축하메세지 이미지 조회(하객용)
+router.get("/guest/images/:id", getAllCelebrationMsgImagesForGuest);
+
+// 3. 개인 축하메세지 조회
 router.get("/:id", getMyCelebrationMsg);
 
-// 3. 개인 축하메세지 등록
+// 4. 개인 축하메세지 등록
 router.post("/", postMyCelebrationMsg);
 
-// 4. 개인 축하메세지 수정
+// 5. 개인 축하메세지 수정
 router.put("/:id", putMyCelebrationMsg);
 
-// 5. 개인 축하메세지 삭제
+// 6. 개인 축하메세지 삭제
 router.delete("/:id", deleteMyCelebrationMsg);
 
-// 6. 개인 축하메세지 어드민 삭제
+// 7. 개인 축하메세지 어드민 삭제
 router.delete("/admin/:id", authToken, deleteCelebrationMsgByAdmin);
 
 export default router;


### PR DESCRIPTION
## 📝 작업 내용
> 전체 축하메세지에서 이미지들만 조회하는 API를 추가하였습니다. 이는 관리자용(토큰 포함)과 하객용(토큰 포함 x, 대신 특정 사용자의 포토톡 조회하도록 userId 포함) 2개의 API를 따로 구현하였습니다.
> 라우팅 및 req 요청 방법은 팀 노션 / 개발 문서 / 포토톡 관리에 적어놓았으니 참고하시고 테스트해주시면 감사하겠습니다

