### PR TITLE
feat : 접근 제한 API  추가

### DIFF
--- a/src/controllers/invitationController.ts
+++ b/src/controllers/invitationController.ts
@@ -68,7 +68,7 @@ export const getInvitationCredential: RequestHandler = async (
 ): Promise<void> => {
   try {
     const userInfo: IUser = req.userInfo;
-    if(!userInfo){
+    if(!userInfo || !userInfo.id){
       res
       .status(StatusCodes.UNAUTHORIZED)
       .json({ message: "허용되지않는 접근입니다 토큰 필요" });

--- a/src/controllers/invitationController.ts
+++ b/src/controllers/invitationController.ts
@@ -61,6 +61,37 @@ export const getInvitation: RequestHandler = async (req: Request, res: Response,
     }
 };
 
+export const getInvitationCredential: RequestHandler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const userInfo: IUser = req.userInfo;
+    if(!userInfo){
+      res
+      .status(StatusCodes.UNAUTHORIZED)
+      .json({ message: "허용되지않는 접근입니다 토큰 필요" });
+      return;
+    }
+    const invitationId: number = validateIdParam(req.params.id);
+    const invitation = await invitationService.getInvitationWithCredential({
+      userId: userInfo.id as number,
+      invitationId,
+    });
+    if (invitation) {
+      res.status(StatusCodes.OK).json(invitation);
+      return;
+    }
+    res.status(StatusCodes.OK).json([]);
+  } catch (err) {
+    res
+      .status(StatusCodes.NOT_FOUND)
+      .json({ message: "해당 청첩장이 없습니다" });
+    next(err);
+  }
+};
+
 export const putInvitation: RequestHandler = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
         const invitationId: number = validateIdParam(req.params.id);

--- a/src/repositories/invitationRepository.ts
+++ b/src/repositories/invitationRepository.ts
@@ -168,6 +168,55 @@ export const getInvitationsByUserId = async (userId: number) => {
   }
 };
 
+export const getInvitationWithCredential = async ({
+  userId,
+  invitationId,
+}: {
+  userId: number;
+  invitationId: number;
+}) => {
+  try {
+    return await db.Invitation.findOne({
+      where: { userId, id: invitationId },
+      include: [
+        {
+          model: db.Calendar,
+          as: "calendars",
+          required: false,
+        },
+        {
+          model: db.Map,
+          as: "maps",
+          required: false,
+        },
+        {
+          model: db.Gallery,
+          as: "galleries",
+          required: false,
+        },
+        {
+          model: db.Account,
+          as: "accounts",
+          required: false,
+        },
+        {
+          model: db.Contact,
+          as: "contacts",
+          required: false,
+        },
+        {
+          model: db.Notice,
+          as: "notices",
+          required: false,
+        },
+      ],
+    });
+  } catch (err) {
+    throw new Error(`청첩장 조회 에러: ${(err as Error).message}`);
+  }
+};
+
+
 export const updateInvitation = async (invitationId: number, updatedData: Partial<InvitationData>) => {
   try {
     const [affectedRows] = await db.Invitation.update(updatedData, {

--- a/src/routes/invitationRouter.ts
+++ b/src/routes/invitationRouter.ts
@@ -455,7 +455,7 @@ router.get('/', authToken, getInvitations);
 router.get('/:id', (req: Request<Params>, res: Response, next: NextFunction) => {
     getInvitation(req, res, next);
 });
-router.get('/:id/credential', (req: Request<Params>, res: Response, next: NextFunction) => {
+router.get('/:id/credential',authToken, (req: Request<Params>, res: Response, next: NextFunction) => {
     getInvitationCredential(req, res, next);
 });
 router.put('/:id', authToken, (req: Request<Params>, res: Response, next: NextFunction) => {

--- a/src/routes/invitationRouter.ts
+++ b/src/routes/invitationRouter.ts
@@ -1,6 +1,6 @@
 import express, {Request, Response, NextFunction} from 'express';
 const router = express.Router();
-import {postInvitation, getInvitation, putInvitation, deleteInvitation, getInvitations} from "../controllers/invitationController"
+import {postInvitation, getInvitation, putInvitation, deleteInvitation, getInvitations, getInvitationCredential} from "../controllers/invitationController"
 import {authToken} from "../middlewares/authToken";
 
 // params에 사용될 id 타입 정의
@@ -454,6 +454,9 @@ router.get('/', authToken, getInvitations);
 // params로 id를 받아오는 router들은 타입을 지정해줘야 함
 router.get('/:id', (req: Request<Params>, res: Response, next: NextFunction) => {
     getInvitation(req, res, next);
+});
+router.get('/:id/credential', (req: Request<Params>, res: Response, next: NextFunction) => {
+    getInvitationCredential(req, res, next);
 });
 router.put('/:id', authToken, (req: Request<Params>, res: Response, next: NextFunction) => {
     putInvitation(req, res, next);

--- a/src/services/invitationService.ts
+++ b/src/services/invitationService.ts
@@ -314,3 +314,18 @@ export const getInvitationsByUserId = async ( userId: number ): Promise<Invitati
     throw new Error('청첩장 조회 에러');
   }
 };
+
+
+export const getInvitationWithCredential = async (
+  req: RequestType<typeof invitationRepository.getInvitationWithCredential>
+): Promise<InvitationData | null> => {
+  try {
+    const invitation = await invitationRepository.getInvitationWithCredential(
+      req
+    );
+    return invitation || null;
+  } catch (err: unknown) {
+    if (err instanceof Error) console.error("청첩장 조회 에러:", err.message);
+    throw new Error("청첩장 조회 에러");
+  }
+};

--- a/src/types/express/index.d.ts
+++ b/src/types/express/index.d.ts
@@ -1,5 +1,5 @@
-import { Request } from 'express';
-import { User as IUser } from '../../interfaces/user.interface';
+import { Request } from "express";
+import { User as IUser } from "../../interfaces/user.interface";
 
 declare global {
   namespace Express {
@@ -8,4 +8,8 @@ declare global {
       userId: number;
     }
   }
+
+  type RequestType<T> = T extends (arg: infer R, ...args: any[]) => any
+    ? R
+    : never;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

  > 기존에  청첩장 GET 요청에   토큰없이 사용가능한  API 와 userID 만 포한됨 API 두가지 밖에 없는것 같아서 추가적으로 단일 청첩장 요청시에 토큰까지 확인하고 응답하는 API를 추가했습니다. 
 
 ## 추가한 이유 
 청첩장 API 호출할때 토큰이 없을 경우 리다이렉팅 처리를 하기 위해서, 또한 결과 페이지 완성본과 API 를 구분하기 위해서 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

## 💬 리뷰 요구사항(선택)

>  최대한 구현 되어있는 코드에서  구현했지만 빠진 부분이나 수정 되어야할부분 있으면 알려주시면 바로 반영하겠습니다. 
